### PR TITLE
Settings styling

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -84,7 +84,6 @@
 					</label>
 				</div>
 			</form>
-			<input type="button" id="confirm-settings" value="Apply Changes">
 		</div>
 		<div id="faq">
 			<h3>Where do I get started?</h3>

--- a/source/main.css
+++ b/source/main.css
@@ -235,10 +235,11 @@ html {
 }
 
 #select-settings > select {
-	width:60px; 
-	height: 60px;
+	width: 6ch;
+	height: 3ch;
 	margin-top: 20px;
-	margin-left: 130px;
+	margin-left: 110px;
+	font-size: 30px;
 }
 
 #select-settings p {

--- a/source/settings.js
+++ b/source/settings.js
@@ -88,8 +88,10 @@ document.addEventListener('DOMContentLoaded', () => {
 	document.getElementById('settings-button').addEventListener('click', () => {
 		window.app.settings.toSettings();
 	});
-	document.getElementById('confirm-settings').addEventListener('click', () => {
+	document.getElementById('pomo-length').addEventListener('input', () => {
 		window.app.settings.getPomoLength();
+	});
+	document.getElementById('display-seconds').addEventListener('input', () => {
 		window.app.settings.getTimerStyle();
 	});
 	document.getElementById('home-button').addEventListener('click', () => {


### PR DESCRIPTION
- Settings: apply immediately and modern design
- CSS: replace checkbox with toggle switch
    - Researched around and custom styling of checkbox is beyond savaging on Firefox.  The only way to make this work is to have everything custom, which is non-trivial. Replaced it with a toggle switch instead because of the simplicity and since it's an immediate on-off switch as well which is more fitting to use a toggle switch for.